### PR TITLE
ADD a text editor to theia-base.

### DIFF
--- a/theia-base/Dockerfile
+++ b/theia-base/Dockerfile
@@ -45,7 +45,8 @@ RUN set -ex; \
     libffi-dev libexpat1-dev \
     libgdbm-dev liblzma-dev zlib1g-dev \
     libsqlite3-dev libssl-dev openssl \
-    libsecret-1-0 libsecret-1-dev sqlite3 libbz2-dev bzip2 fzf; \
+    libsecret-1-0 libsecret-1-dev sqlite3 libbz2-dev bzip2 fzf \
+    nano; \
   apt remove -y python python-pip python3-pip python3; \
   cd /; \
   echo 'LANG=en_US.UTF-8' > /etc/locale.conf; \


### PR DESCRIPTION
This adds a text editor so that "git commit" works. I prefer vim but students might not know how to exit it, so I ended up adding nano (and vim takes longer to install if that matters).

Using the code editor UI for committing is always an option, but students inevitably need to work with the terminal anyway.

Signed-off-by: Zixuan James Li <p359101898@gmail.com>